### PR TITLE
Fix namespaces and preview rendering for WPF screensaver

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -1,9 +1,6 @@
-﻿<Application x:Class="NovaScreenSaver.App"
+<Application x:Class="NovaScreenSaver.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:NovaScreenSaver"
-             StartupUri="MainWindow.xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
-         
     </Application.Resources>
 </Application>

--- a/Rendering/Rendering/AuroraRenderer.cs
+++ b/Rendering/Rendering/AuroraRenderer.cs
@@ -1,7 +1,7 @@
 using System;
-using AuroraScreenSaver.Settings;
+using NovaScreenSaver.Settings;
 
-namespace AuroraScreenSaver.Rendering
+namespace NovaScreenSaver.Rendering
 {
     internal sealed class AuroraRenderer : IRenderer
     {

--- a/Rendering/Rendering/OrbsRenderer.cs
+++ b/Rendering/Rendering/OrbsRenderer.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using AuroraScreenSaver.Settings;
+using NovaScreenSaver.Settings;
 
-namespace AuroraScreenSaver.Rendering
+namespace NovaScreenSaver.Rendering
 {
     internal sealed class OrbsRenderer : IRenderer
     {

--- a/Rendering/Rendering/PerlinNoise.cs
+++ b/Rendering/Rendering/PerlinNoise.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace AuroraScreenSaver.Rendering
+namespace NovaScreenSaver.Rendering
 {
     internal static class PerlinNoise
     {

--- a/ScreensaverWindow.xaml
+++ b/ScreensaverWindow.xaml
@@ -1,45 +1,8 @@
-using System;
-using System.Windows;
-
-namespace NovaScreenSaver
-{
-    public partial class ScreensaverWindow : Window
-    {
-        private System.Drawing.Point _mouseOrigin;
-        private readonly bool _isPreview;
-        private readonly System.Windows.Forms.Screen? _screen;
-        private readonly Settings.Config _cfg;
-
-        public ScreensaverWindow(Settings.Config cfg, System.Windows.Forms.Screen? screen, bool isPreview = false)
-        {
-            InitializeComponent();
-            _cfg = cfg; _screen = screen; _isPreview = isPreview;
-            Loaded += OnLoaded;
-            MouseMove += (_, __) => CheckMouse();
-            MouseDown += (_, __) => Exit();
-            KeyDown += (_, __) => Exit();
-        }
-
-        private void OnLoaded(object sender, RoutedEventArgs e)
-        {
-            if (!_isPreview && _screen != null)
-            {
-                WindowStartupLocation = WindowStartupLocation.Manual;
-                Left = _screen.Bounds.Left; Top = _screen.Bounds.Top;
-                Width = _screen.Bounds.Width; Height = _screen.Bounds.Height;
-            }
-            _mouseOrigin = System.Windows.Forms.Control.MousePosition;
-            Renderer.Initialize(_cfg);
-            Renderer.Start();
-        }
-
-        private void CheckMouse()
-        {
-            if (_isPreview) return;
-            var pos = System.Windows.Forms.Control.MousePosition;
-            if (Math.Abs(pos.X - _mouseOrigin.X) > 8 || Math.Abs(pos.Y - _mouseOrigin.Y) > 8) Exit();
-        }
-
-        private void Exit() => System.Windows.Application.Current.Shutdown();
-    }
-}
+<Window x:Class="NovaScreenSaver.ScreensaverWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:NovaScreenSaver"
+        WindowStyle="None" ResizeMode="NoResize" ShowInTaskbar="False"
+        WindowState="Maximized" Topmost="True" Background="Black">
+    <local:RendererView x:Name="Renderer" />
+</Window>

--- a/UI/PreviewCanvas.cs
+++ b/UI/PreviewCanvas.cs
@@ -1,0 +1,13 @@
+using NovaScreenSaver.Settings;
+
+namespace NovaScreenSaver.UI
+{
+    internal class PreviewCanvas : RendererView
+    {
+        public void Apply(Config cfg)
+        {
+            Initialize(cfg);
+            Start();
+        }
+    }
+}

--- a/UI/SettingsWindow.xaml
+++ b/UI/SettingsWindow.xaml
@@ -1,8 +1,8 @@
-<Window x:Class="AuroraScreenSaver.UI.SettingsWindow"
+<Window x:Class="NovaScreenSaver.UI.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:local="clr-namespace:AuroraScreenSaver.UI"
-        Title="Aurora Screensaver Settings" Height="520" Width="720"
+        xmlns:local="clr-namespace:NovaScreenSaver.UI"
+        Title="Nova Screensaver Settings" Height="520" Width="720"
         WindowStartupLocation="CenterScreen">
   <Grid Margin="16">
     <Grid.ColumnDefinitions>

--- a/UI/SettingsWindow.xaml.cs
+++ b/UI/SettingsWindow.xaml.cs
@@ -1,8 +1,8 @@
 using System.Windows;
-using AuroraScreenSaver.Rendering;
-using AuroraScreenSaver.Settings;
+using NovaScreenSaver.Rendering;
+using NovaScreenSaver.Settings;
 
-namespace AuroraScreenSaver.UI
+namespace NovaScreenSaver.UI
 {
     public partial class SettingsWindow : Window
     {


### PR DESCRIPTION
## Summary
- Align namespaces to `NovaScreenSaver`
- Provide XAML layout for screensaver window and settings
- Add preview canvas control for live settings preview

## Testing
- `dotnet build /p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3e4c1b10832b9c32618c2149d749